### PR TITLE
Evitar atualização de gráficos com slider

### DIFF
--- a/simulador-unificado.js
+++ b/simulador-unificado.js
@@ -117,7 +117,7 @@ function isPeriodAvailableForSelectedFunds(periodValue) {
 }
 
 // Função para atualizar estado dos botões de período
-function updatePeriodButtonsState() {
+function updatePeriodButtonsState(preventChartRegeneration = false) {
   const periodButtons = document.querySelectorAll('.filter-period-button');
   let hasEnabledButton = false;
   let fallbackButton = null;
@@ -152,8 +152,10 @@ function updatePeriodButtonsState() {
   if (!activeButton && fallbackButton) {
     fallbackButton.classList.add('active');
     filterPeriod = fallbackButton.getAttribute('data-value');
-    // Regenera os gráficos com o novo período
-    regenerateChartsWithFilter();
+    // Regenera os gráficos com o novo período apenas se não for uma chamada do rangeSlider
+    if (!preventChartRegeneration) {
+      regenerateChartsWithFilter();
+    }
   }
 }
 
@@ -1517,7 +1519,8 @@ function initializeSimulator() {
         calculateWalletComposition();
 
         // Atualiza o estado dos botões de período baseado na nova seleção
-        updatePeriodButtonsState();
+        // Passa true para evitar regeneração dos gráficos durante movimento do rangeSlider
+        updatePeriodButtonsState(true);
       });
 
       rangeColors(


### PR DESCRIPTION
Prevent profitability and drawdown charts from regenerating when the rangeSlider is moved.

Moving the rangeSlider was unnecessarily regenerating the profitability and drawdown charts because `updatePeriodButtonsState()` was called on rangeSlider input, and it contained a call to `regenerateChartsWithFilter()`. This change introduces a flag to prevent this regeneration when the call originates from the rangeSlider.

---
<a href="https://cursor.com/background-agent?bcId=bc-839bd475-8149-48fe-87f9-88e58b198093">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-839bd475-8149-48fe-87f9-88e58b198093">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>